### PR TITLE
Enable or disable the selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ The `<SelectableGroup />` component accepts a few optional props:
 * `allowClickWithoutSelected` (Boolean) When disabled items can be selected by click only if there is more than 1 already selected item.
 * `fixedPosition` (Boolean) Whether the `<SelectableGroup />` container is a fixed or absolutely positioned element or the grandchild of one.
 * `resetOnStart` (Boolean) Unselect all items when you start a new drag. Default value is `false`.
+* `disable` (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items. Default value is `false`.

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ The `<SelectableGroup />` component accepts a few optional props:
 * `allowClickWithoutSelected` (Boolean) When disabled items can be selected by click only if there is more than 1 already selected item.
 * `fixedPosition` (Boolean) Whether the `<SelectableGroup />` container is a fixed or absolutely positioned element or the grandchild of one.
 * `resetOnStart` (Boolean) Unselect all items when you start a new drag. Default value is `false`.
-* `disable` (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items. Default value is `false`.
+* `disabled` (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items. Default value is `false`.

--- a/example/App.js
+++ b/example/App.js
@@ -46,7 +46,6 @@ class App extends Component {
           onSelectionClear={this.handleSelectionClear}
           onSelectionFinish={this.handleSelectionFinish}
           ignoreList={['.not-selectable', '.item:nth-child(10)', '.item:nth-child(27)']}
-          disabled
         >
           <List items={this.props.items} />
         </SelectableGroup>

--- a/example/App.js
+++ b/example/App.js
@@ -46,6 +46,7 @@ class App extends Component {
           onSelectionClear={this.handleSelectionClear}
           onSelectionFinish={this.handleSelectionFinish}
           ignoreList={['.not-selectable', '.item:nth-child(10)', '.item:nth-child(27)']}
+          disabled
         >
           <List items={this.props.items} />
         </SelectableGroup>

--- a/example/index.html
+++ b/example/index.html
@@ -169,6 +169,8 @@
       <li><code>fixedPosition</code> (Boolean) Whether the <code>&lt;SelectableGroup /&gt;</code> container is a fixed/absolute
         position element or the grandchild of one.</li>
       <li><code>resetOnStart</code> (Boolean) Unselect all items when you start a new drag. Default value is <code>false</code>.</li>
+      <li><code>disabled</code> (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items.
+        Default value is <code>false</code>.</li>
     </ul>
     <h2><a class="anchor" href="#development" id="development"><span class="octicon octicon-link"></span></a>Development</h2>
     <h3><a class="anchor" href="#clean-lib-folder" id="clean-lib-folder"><span class="octicon octicon-link"></span></a>Clean

--- a/src/SelectableGroup.js
+++ b/src/SelectableGroup.js
@@ -5,7 +5,7 @@ import getBoundsForNode from './getBoundsForNode'
 import doObjectsCollide from './doObjectsCollide'
 import Selectbox from './Selectbox'
 
-const noop = () => {}
+const noop = () => { }
 
 class SelectableGroup extends Component {
   static propTypes = {
@@ -21,6 +21,7 @@ class SelectableGroup extends Component {
     enableDeselect: bool,
     mixedDeselect: bool,
     resetOnStart: bool,
+    disabled: bool,
     /**
      * Scroll container selector
      */
@@ -71,6 +72,7 @@ class SelectableGroup extends Component {
     allowClickWithoutSelected: true,
     selectionModeClass: 'in-selection-mode',
     resetOnStart: false,
+    disabled: false,
   }
 
   static childContextTypes = {
@@ -391,7 +393,7 @@ class SelectableGroup extends Component {
   }
 
   mouseDown = e => {
-    if (this.mouseDownStarted) return
+    if (this.mouseDownStarted || this.props.disabled) return
     if (this.props.resetOnStart) {
       this.clearSelection()
     }

--- a/src/Selectbox.js
+++ b/src/Selectbox.js
@@ -5,6 +5,7 @@ class Selectbox extends Component {
   static propTypes = {
     fixedPosition: bool,
     className: string,
+    disabled: bool,
   }
 
   static defaultProps = {
@@ -34,7 +35,13 @@ class Selectbox extends Component {
       cursor: 'default',
     }
 
+    const disabled = this.props.disabled
+
+    if (disabled) {
+      return null
+    }
     return (
+
       <div>
         {
           this.state.isBoxSelecting &&


### PR DESCRIPTION
This PR enable the possibility to enable or disable the component by a prop.

It's useful if you want to prevent other drags of other components. 

Example of the problem solved with this:

![ezgif-4-ff06a6f7a8](https://user-images.githubusercontent.com/1420409/29709802-1c2ed43a-898e-11e7-94f0-fbca8ae01f23.gif)
