### PR TITLE
Disable start for specific items

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `<SelectableGroup />` component accepts a few optional props:
 * `mixedDeselect` (Boolean) When enabled items can be selected and deselected with selectbox at the same time, `enableDeselect` should be set to `true`.
 * `scrollContainer` (String) Selector of scroll container which will be used to calculate selectbox position. If not specified SelectableGroup element will be used as scroll container.
 * `ignoreList` (Array) Array of ignored selectors.
-* `inIgnoreStartList` (Array) Array of ignored start selectors. If you want that the selectable does not fired if start in one specific node class.
+* `ignoreStartList` (Array) Array of ignored start selectors. If you want that the selectable does not fired if start in one specific node class.
 * `clickableClassName` (String) On elements with specified selector click item containing this element will be selected.
 * `tolerance` (Number) The amount of buffer to add around your `<SelectableGroup />` container, in pixels.
 * `className` (String) Class of selectable group element.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The `<SelectableGroup />` component accepts a few optional props:
 * `mixedDeselect` (Boolean) When enabled items can be selected and deselected with selectbox at the same time, `enableDeselect` should be set to `true`.
 * `scrollContainer` (String) Selector of scroll container which will be used to calculate selectbox position. If not specified SelectableGroup element will be used as scroll container.
 * `ignoreList` (Array) Array of ignored selectors.
+* `inIgnoreStartList` (Array) Array of ignored start selectors. If you want that the selectable does not fired if start in one specific node class.
 * `clickableClassName` (String) On elements with specified selector click item containing this element will be selected.
 * `tolerance` (Number) The amount of buffer to add around your `<SelectableGroup />` container, in pixels.
 * `className` (String) Class of selectable group element.

--- a/example/index.html
+++ b/example/index.html
@@ -157,8 +157,8 @@
       <li><code>scrollContainer</code> (String) Selector of scroll container which will be used to calculate selectbox position.
         If not specified SelectableGroup element will be used as scroll container.</li>
       <li><code>ignoreList</code> (Array) Array of ignored selectors.</li>
-      <li><code>ignoreList</code> (Array) Array of ignored start selectors. If you want that the selectable does not fired if
-        start in one specific node class.</li>
+      <li><code>ignoreStartList</code> (Array) Array of ignored start selectors. If you want that the selectable does not fired
+        if start in one specific node class.</li>
       <li><code>clickableClassName</code> (String) On element with specified selector click item cotaining this element will
         be selected.</li>
       <li><code>tolerance</code> (Number) The amount of buffer to add around your <code>&lt;SelectableGroup /&gt;</code> container,

--- a/example/index.html
+++ b/example/index.html
@@ -157,6 +157,8 @@
       <li><code>scrollContainer</code> (String) Selector of scroll container which will be used to calculate selectbox position.
         If not specified SelectableGroup element will be used as scroll container.</li>
       <li><code>ignoreList</code> (Array) Array of ignored selectors.</li>
+      <li><code>ignoreList</code> (Array) Array of ignored start selectors. If you want that the selectable does not fired if
+        start in one specific node class.</li>
       <li><code>clickableClassName</code> (String) On element with specified selector click item cotaining this element will
         be selected.</li>
       <li><code>tolerance</code> (Number) The amount of buffer to add around your <code>&lt;SelectableGroup /&gt;</code> container,

--- a/src/SelectableGroup.js
+++ b/src/SelectableGroup.js
@@ -412,9 +412,7 @@ class SelectableGroup extends Component {
 
   mouseDown = e => {
     if (this.mouseDownStarted || this.props.disabled) return
-    if (this.props.resetOnStart) {
-      this.clearSelection()
-    }
+
     this.mouseDownStarted = true
     this.mouseUpStarted = false
     e = this.desktopEventCoords(e)
@@ -423,6 +421,10 @@ class SelectableGroup extends Component {
     if (this.inIgnoreStartList(e.target)) {
       this.mouseDownStarted = false
       return
+    }
+
+    if (this.props.resetOnStart) {
+      this.clearSelection()
     }
 
     this.updateWhiteListNodes()


### PR DESCRIPTION
Hi again @valerybugakov!! 

Disabled is a good option, but we need a granulated control if the selectable start in a specific item. 

For example, if you want to drag an item, but you don't want to fire the SelectableGroup, you can add a list of class items (like ignored list), but it just works for stater items. If you start to drag on an item that meet the class, the SelectableGroup is not fired ;)

What do you think? We need this for our project, here you have a GIF:

![ezgif-1-5c1a40fb8a](https://user-images.githubusercontent.com/1420409/29779499-02cce4d2-8c13-11e7-9f22-75c1f6ef1a68.gif)


Thanks!