### PR TITLE
Do not clear selection on ignored items

### DIFF
--- a/src/SelectableGroup.js
+++ b/src/SelectableGroup.js
@@ -373,18 +373,19 @@ class SelectableGroup extends Component {
 
   mouseDown = e => {
     if (this.mouseDownStarted || this.props.disabled) return
-    if (this.props.resetOnStart) {
-      this.clearSelection()
-    }
-    this.mouseDownStarted = true
-    this.mouseUpStarted = false
-    e = this.desktopEventCoords(e)
 
     this.updateWhiteListNodes()
     if (this.inIgnoreList(e.target)) {
       this.mouseDownStarted = false
       return
     }
+
+    if (this.props.resetOnStart) {
+      this.clearSelection()
+    }
+    this.mouseDownStarted = true
+    this.mouseUpStarted = false
+    e = this.desktopEventCoords(e)
 
     if (!this.props.globalMouse && !isNodeInRoot(e.target, this.selectableGroup)) {
       const offsetData = getBoundsForNode(this.selectableGroup)


### PR DESCRIPTION
Hi @valerybugakov.
At the moment any interaction with ignored elements while `resetOnStart` is turned on  leads to loosing of current selection. It prevents from doing any stuff with items such text selection, pressing, DnD and so on. (In my case it's DnD for selected items)

![selectionshow](https://user-images.githubusercontent.com/15232584/36937792-ca585dd4-1f29-11e8-842f-f6287bad2c1e.gif)

If you consider it as a breaking change, then may be additional flag will work:
```
<SelectableGroup
  resetOnStart
  resetOnIgnoreList={boolean} // default: true
>
```

Please, let me know what you think.
Thanks!