### PR TITLE
Bugfix for selecting element with default "selected", new setting canStartOnSelectable

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -169,6 +169,7 @@
       <li><code>fixedPosition</code> (Boolean) Whether the <code>&lt;SelectableGroup /&gt;</code> container is a fixed/absolute
         position element or the grandchild of one.</li>
       <li><code>resetOnStart</code> (Boolean) Unselect all items when you start a new drag. Default value is <code>false</code>.</li>
+      <li><code>canStartOnSelectable</code> (Boolean) Enable or disable starting selection on selectable element. Can be useful to be used with drag, when disabled. Default value is <code>true</code>.</li>
       <li><code>disabled</code> (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items.
         Default value is <code>false</code>.</li>
       <li><code>delta</code> (Number) Value of the CSS transform property scaled list, useful if your list of items in <code>&lt;SelectableGroup /&gt;</code>        is wrapped by a scale css transform property. Default value is <code>1</code>.</li>

--- a/src/SelectableGroup.js
+++ b/src/SelectableGroup.js
@@ -23,6 +23,7 @@ class SelectableGroup extends Component {
     mixedDeselect: bool,
     deselectOnEsc: bool,
     resetOnStart: bool,
+    canStartOnSelectable: bool,
     disabled: bool,
     delta: number,
     /**
@@ -74,6 +75,7 @@ class SelectableGroup extends Component {
     allowClickWithoutSelected: true,
     selectionModeClass: 'in-selection-mode',
     resetOnStart: false,
+    canStartOnSelectable: true,
     disabled: false,
     deselectOnEsc: true,
     delta: 1,
@@ -388,6 +390,12 @@ class SelectableGroup extends Component {
 
   mouseDown = e => {
     if (this.mouseDownStarted || this.props.disabled) return
+
+    // Don't init selection on selectableElement"
+    // TODO add this to configuration props
+    if (!this.props.canStartOnSelectable && e.target != e.currentTarget) {
+      return;
+    }
 
     this.updateWhiteListNodes()
     if (this.inIgnoreList(e.target)) {


### PR DESCRIPTION
- fixed bug for elements, that have default selected prop
- added new setting canStartOnSelectable. When false, cant start selection on selectable element, only outside