### PR TITLE
Fix unwritable style property error.

### DIFF
--- a/src/SelectableGroup.js
+++ b/src/SelectableGroup.js
@@ -586,7 +586,7 @@ class SelectableGroup extends Component {
       <SelectableGroupContext.Provider value={this.contextValue}>
         <this.props.component
           ref={this.getGroupRef}
-          style={Object.assign(this.defaultContainerStyle, this.props.style)}
+          style={Object.assign({}, this.defaultContainerStyle, this.props.style)}
           className={`${this.props.className} ${
             this.state.selectionMode ? this.props.selectionModeClass : ''
           }`}


### PR DESCRIPTION
When babel defines properties, by default it does not make them writable. In this case, `this.defaultContainerStyle` was not writable, and `Object.assign` was attempting to merge in a style object into it, throwing an error. This fixes the bug.