### PR TITLE
Add options selectOnClick  and allowShiftClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ The `<SelectableGroup />` component accepts a few optional props:
 - `deselectOnEsc` (Boolean) Unselect all items on ESC keydown/keyup events. Default value is `true`. Using `ref` on `SelectableGroup` gives access to `ref.clearSelection()` method to unselect all items programmatically.
 - `disabled` (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items. Default value is `false`.
 - `delta` (Number) Value of the CSS transform property scaled list, useful if your list of items in `<SelectableGroup />` is wrapped by a scale css transform property. Default value is `1`.
-- `selectOnClick` (Boolean) Allow selecting by clicking items. Default value us `true`
-- `allowShiftClick` (Boolean) Perform select actions even though the shift key is down when clicking or dragging. Default value us `false`
+- `selectOnClick` (Boolean) Allow selecting by clicking items. Default value is `true`
+- `allowShiftClick` (Boolean) Perform select actions even though the shift key is down when clicking or dragging. Default value is `false`

--- a/README.md
+++ b/README.md
@@ -139,3 +139,5 @@ The `<SelectableGroup />` component accepts a few optional props:
 - `deselectOnEsc` (Boolean) Unselect all items on ESC keydown/keyup events. Default value is `true`. Using `ref` on `SelectableGroup` gives access to `ref.clearSelection()` method to unselect all items programmatically.
 - `disabled` (Boolean) Enable or disable the selectable draggable, useful if you want to enable drag of sub-items. Default value is `false`.
 - `delta` (Number) Value of the CSS transform property scaled list, useful if your list of items in `<SelectableGroup />` is wrapped by a scale css transform property. Default value is `1`.
+- `selectOnClick` (Boolean) Allow selecting by clicking items. Default value us `true`
+- `allowShiftClick` (Boolean) Perform select actions even though the shift key is down when clicking or dragging. Default value us `false`

--- a/src/SelectableGroup.tsx
+++ b/src/SelectableGroup.tsx
@@ -51,6 +51,8 @@ export type TSelectableGroupProps = {
   resetOnStart?: boolean
   disabled?: boolean
   delta?: number
+  allowShiftClick?: boolean
+  selectOnClick?: boolean
   /**
    * Scroll container selector
    */
@@ -104,7 +106,9 @@ class SelectableGroup extends Component<TSelectableGroupProps> {
     disabled: false,
     deselectOnEsc: true,
     fixedPosition: false,
-    delta: 1
+    delta: 1,
+    allowShiftClick: false,
+    selectOnClick: true
   }
 
   state = { selectionMode: false }
@@ -442,7 +446,9 @@ class SelectableGroup extends Component<TSelectableGroupProps> {
   }
 
   mouseDown = (e: Event) => {
-    const isNotLeftButtonClick = !e.type.includes('touch') && !detectMouseButton(e as any, 1)
+    const isNotLeftButtonClick =
+      !e.type.includes('touch') &&
+      !detectMouseButton(e as any, 1, { allowShiftClick: this.props.allowShiftClick })
     if (this.mouseDownStarted || this.props.disabled || isNotLeftButtonClick) {
       return
     }
@@ -557,6 +563,10 @@ class SelectableGroup extends Component<TSelectableGroupProps> {
   }
 
   handleClick(evt: any, top: number, left: number) {
+    if (!this.props.selectOnClick) {
+      return
+    }
+
     const { clickClassName, allowClickWithoutSelected, onSelectionFinish } = this.props
     const classNames = (evt.target as HTMLElement).classList || []
     const isMouseUpOnClickElement = Array.from(classNames).indexOf(clickClassName!) > -1

--- a/src/utils/detectMouseButton.ts
+++ b/src/utils/detectMouseButton.ts
@@ -1,13 +1,21 @@
 import { MouseEvent } from 'react'
 
+type TDetectMouseButtonOptions = {
+  allowShiftClick?: Boolean
+}
+
 /**
  * @buttonNumber
  * 1: Left button
  * 2: Middle/Right button
  * 3: Right/Back button
  */
-export function detectMouseButton(evt: MouseEvent<HTMLElement>, buttonNumber = 1) {
-  if (evt.metaKey || evt.ctrlKey || evt.altKey || evt.shiftKey) {
+export function detectMouseButton(
+  evt: MouseEvent<HTMLElement>,
+  buttonNumber = 1,
+  options: TDetectMouseButtonOptions = {}
+) {
+  if (evt.metaKey || evt.ctrlKey || evt.altKey || (evt.shiftKey && !options.allowShiftClick)) {
     return false
   }
 


### PR DESCRIPTION
Two new options on `SelectableGroup`:

- `selectOnClick` (Boolean) Allow selecting by clicking items. Default value is `true`
- `allowShiftClick` (Boolean) Perform select actions even though the shift key is down when clicking or dragging. Default value is `false`

Using these it's easy to add functionality where select is controlled by shift, which I think is a pretty common use case.