### PR TITLE
Add option disableSelectStartList

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The `<SelectableGroup />` component accepts a few optional props:
 - `mixedDeselect` (Boolean) When enabled items can be selected and deselected with selectbox at the same time, `enableDeselect` should be set to `true`.
 - `scrollContainer` (String) Selector of scroll container which will be used to calculate selectbox position. If not specified SelectableGroup element will be used as scroll container.
 - `ignoreList` (Array) Array of ignored selectors.
+- `disableSelectStartList` (Array) Array of selectors on which start select is disabled.
 - `clickableClassName` (String) On elements with specified selector click item containing this element will be selected.
 - `tolerance` (Number) The amount of buffer to add around your `<SelectableGroup />` container, in pixels.
 - `className` (String) Class of selectable group element.


### PR DESCRIPTION
The option `ignoreList` is useful to make certain elements ignored by the selection. But sometimes when selection is used in conjunction with other mouse-based functionality it is also useful to be able to abort the start selection process completely. This is provided by `disableSelectStartList`.