### PR TITLE
Fixed invalid props in example code snippet

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -164,7 +164,7 @@
         <pre><span class="pl-k">import</span> <span class="pl-smi">React</span> <span class="pl-k">from</span> <span class="pl-s"><span class="pl-pds">'</span>react<span class="pl-pds">'</span></span>
 <span class="pl-k">import</span> { <span class="pl-smi">createSelectable</span> } <span class="pl-k">from</span> <span class="pl-s"><span class="pl-pds">'</span>react-selectable-fast<span class="pl-pds">'</span></span>
 
-<span class="pl-k">const</span> <span class="pl-c1">SomeComponent</span> <span class="pl-k">=</span> ({ selectableRef, selected, selecting }) <span class="pl-k">=&gt;</span> (
+<span class="pl-k">const</span> <span class="pl-c1">SomeComponent</span> <span class="pl-k">=</span> ({ selectableRef, isSelected, isSelecting }) <span class="pl-k">=&gt;</span> (
   <span class="pl-k">&lt;</span>div ref<span class="pl-k">=</span>{selectableRef}<span class="pl-k">&gt;</span><span class="pl-k">...</span><span class="pl-k">&lt;</span><span class="pl-k">/</span>div<span class="pl-k">&gt;</span>
 )
 


### PR DESCRIPTION
Incorrect props are shown in the example code on the website, in the second code block of the **Usage** section.

`selected` =>`isSelected`
`selecting` => `isSelecting`