### PR TITLE
Added 'disableSelectStartList' to disable select start on certain items

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The `<SelectableGroup />` component accepts a few optional props:
 - `mixedDeselect` (Boolean) When enabled items can be selected and deselected with selectbox at the same time, `enableDeselect` should be set to `true`.
 - `scrollContainer` (String) Selector of scroll container which will be used to calculate selectbox position. If not specified SelectableGroup element will be used as scroll container.
 - `ignoreList` (Array) Array of ignored selectors.
+- `disableSelectStartList` (Array) Array of selectors where select lasso can not be started by dragging mouse. Useful if you want to enable drag of selectables.
 - `clickableClassName` (String) On elements with specified selector click item containing this element will be selected.
 - `tolerance` (Number) The amount of buffer to add around your `<SelectableGroup />` container, in pixels.
 - `className` (String) Class of selectable group element.

--- a/website/index.html
+++ b/website/index.html
@@ -227,6 +227,10 @@
         </li>
         <li><code>ignoreList</code> (Array) Array of ignored selectors.</li>
         <li>
+          <code>disableSelectStartList</code> (Array) Array of selectors where select lasso can not
+          be started by dragging mouse. Useful if you want to enable drag of selectables.
+        </li>
+        <li>
           <code>clickableClassName</code> (String) On element with specified selector click item
           cotaining this element will be selected.
         </li>


### PR DESCRIPTION
Hi, I love your package. I wanted my selectables to be draggable without having to disable the SelectableGroup (to get selectable and draggable behaviour like the files/folders in an OS GUI like Windows/Mac etc). To achieve this I sort of mimicked how you implemented the ignore list. So with this PR, if you try to start a lasso drag on a selectable item that has a certain class, you won't be able to.

If you like this addition feel free to merge it. If you need anything else from me, like code convention clean up, testing, anything at all, let me know.

Again, thanks for your package.