### PR TITLE
Add methods to select / deselect by predicate

### DIFF
--- a/src/SelectableGroup.tsx
+++ b/src/SelectableGroup.tsx
@@ -451,29 +451,38 @@ export class SelectableGroup extends Component<TSelectableGroupProps> {
     return null
   }
 
-  clearSelection = () => {
-    for (const item of this.selectedItems.values()) {
-      item.setState({ isSelected: false })
-      this.selectedItems.delete(item)
+  deselectItemsByPredicate = (pred: (item: TSelectableItem) => boolean) => {
+    for (const item of this.registry.values()) {
+      if (item.state.isSelected && pred(item)) {
+        item.setState({ isSelected: false })
+        this.selectedItems.delete(item)
+      }
     }
-
     this.setState({ selectionMode: false })
     this.props.onSelectionFinish!([...this.selectedItems])
-    this.props.onSelectionClear!()
   }
 
-  selectAll = () => {
+  selectItemsByPredicate = (pred: (item: TSelectableItem) => boolean) => {
     this.removeIgnoredItemsFromRegistry()
 
     for (const item of this.registry.values()) {
-      if (!item.state.isSelected) {
+      if (!item.state.isSelected && pred(item)) {
         item.setState({ isSelected: true })
         this.selectedItems.add(item)
       }
     }
 
-    this.setState({ selectionMode: true })
-    this.props.onSelectionFinish!([...this.selectedItems])
+      this.setState({ selectionMode: true })
+      this.props.onSelectionFinish!([...this.selectedItems])
+    }
+
+  clearSelection = () => {
+    this.deselectItemsByPredicate(() => true)
+    this.props.onSelectionClear!()
+  }
+
+  selectAll = () => {
+    this.selectItemsByPredicate(() => true)
   }
 
   isInIgnoreList(target: HTMLElement | null) {

--- a/src/SelectableGroup.tsx
+++ b/src/SelectableGroup.tsx
@@ -458,7 +458,7 @@ export class SelectableGroup extends Component<TSelectableGroupProps> {
         this.selectedItems.delete(item)
       }
     }
-    this.setState({ selectionMode: false })
+    this.toggleSelectionMode()
     this.props.onSelectionFinish!([...this.selectedItems])
   }
 
@@ -472,7 +472,7 @@ export class SelectableGroup extends Component<TSelectableGroupProps> {
       }
     }
 
-    this.setState({ selectionMode: true })
+    this.toggleSelectionMode()
     this.props.onSelectionFinish!([...this.selectedItems])
   }
 

--- a/src/SelectableGroup.tsx
+++ b/src/SelectableGroup.tsx
@@ -472,9 +472,9 @@ export class SelectableGroup extends Component<TSelectableGroupProps> {
       }
     }
 
-      this.setState({ selectionMode: true })
-      this.props.onSelectionFinish!([...this.selectedItems])
-    }
+    this.setState({ selectionMode: true })
+    this.props.onSelectionFinish!([...this.selectedItems])
+  }
 
   clearSelection = () => {
     this.deselectItemsByPredicate(() => true)


### PR DESCRIPTION
Hi, thank you for developing the cool package.

This PR adds two methods: `selectItemsByPredicate` and `deselectItemsByPredicate` to control selection from js interface (not by user manipulation). This may be useful to implement "selected by default" for example (#84).

I'm not sure that the interface is excellent (`selectItems (items: Array<TSelectableItem>)` might be another option I think) but anyways this kind of feature is nice to have IMO.

Thank you.