### PR TITLE
Make selectbox invisible if its size is zero

### DIFF
--- a/src/Selectbox.tsx
+++ b/src/Selectbox.tsx
@@ -40,6 +40,7 @@ export function Selectbox(props: TSelectboxProps) {
     cursor: 'default',
     willChange: 'transform',
     transform: 'translateZ(0)',
+    display: state.width === 0 && state.height === 0 ? 'none' : 'block',
   }
 
   return <div className={className} style={boxStyle} />


### PR DESCRIPTION
This PR makes the Selectbox invisible by setting its `display` property to `none`, iff both width and height of the box is zero.

This avoids rendering a strange dot at the top-left position of the SelectableGroup.

<img width="291" alt="スクリーンショット 2020-06-05 16 40 27" src="https://user-images.githubusercontent.com/3530521/83850680-395d7280-a74c-11ea-82f1-3f3ae81e88da.png">

Thank you and regards.